### PR TITLE
add k8s manifest; add terraform resources for k8s

### DIFF
--- a/.cloud/auth.tf
+++ b/.cloud/auth.tf
@@ -35,3 +35,15 @@ resource "google_project_iam_member" "api_preprocessor_sa_binding_A" {
   project = "contrails-301217"
   role    = google_project_iam_custom_role.api_preprocessor_role.id
 }
+
+resource "google_service_account_iam_binding" "k8s_sa_to_api_preprocessor_sa_binding" {
+  service_account_id = google_service_account.api_preprocessor_sa.id
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "serviceAccount:contrails-301217.svc.id.goog[${kubernetes_service_account.api-preprocessor-k8s-default-sa.id}]",
+  ]
+  depends_on = [
+    kubernetes_service_account.api-preprocessor-k8s-default-sa,
+  ]
+}

--- a/.cloud/k8s.tf
+++ b/.cloud/k8s.tf
@@ -1,0 +1,24 @@
+resource "kubernetes_namespace" "api_preprocessor" {
+  metadata {
+    annotations = {
+      name = "api-preprocessor"
+    }
+    labels = {
+      name = "api-preprocessor"
+    }
+    name = "api-preprocessor"
+  }
+}
+
+resource "kubernetes_service_account" "api-preprocessor-k8s-default-sa" {
+  metadata {
+    name = "api-preprocessor-k8s-default-sa"
+    namespace = kubernetes_namespace.api_preprocessor.id
+    annotations = {
+      "iam.gke.io/gcp-service-account" = google_service_account.api_preprocessor_sa.email
+    }
+  }
+  depends_on = [
+    google_service_account.api_preprocessor_sa,
+  ]
+}

--- a/.cloud/main.tf
+++ b/.cloud/main.tf
@@ -4,6 +4,10 @@ provider "google" {
   zone    = "us-east1-b"
 }
 
+provider "kubernetes" {
+  config_path    = "~/.kube/config"
+}
+
 terraform {
  backend "gcs" {
    bucket  = "contrails-301217-infrastructure"

--- a/k8s_deployment.yaml
+++ b/k8s_deployment.yaml
@@ -1,0 +1,40 @@
+# test deployment for k8s
+# kubectl apply -f k8s_deployment.yaml -n api-preprocessor
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-preprocessor-dev
+  labels:
+    app: api-preprocessor-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-preprocessor-dev
+  template:
+    metadata:
+      labels:
+        app: api-preprocessor-dev
+    spec:
+      serviceAccountName: api-preprocessor-k8s-default-sa
+      containers:
+      - name: api-preprocessor-dev
+        image: us-east1-docker.pkg.dev/contrails-301217/api-preprocessor/api-preprocessor-dev:latest
+        ports:
+        - containerPort: 8080
+        env:
+          - name: SINK_PATH
+            value: "gs://contrails-301217-foobar"
+          - name: API_PREPROCESSOR_SUBSCRIPTION_ID
+            value: "projects/contrails-301217/subscriptions/api-preprocessor-sub-dev"
+          - name: LOG_LEVEL
+            value: "INFO"
+        resources:
+          limits:
+            cpu: "2"
+            ephemeral-storage: "1Gi"
+            memory: "8Gi"
+          requests:
+            cpu: "2"
+            ephemeral-storage: "1Gi"
+            memory: "8Gi"


### PR DESCRIPTION
## Description
This adds a kubernetes Deployment manifest to define a k8s deployment of the api-preprocessor.

The deployment can be dispatched to the `api-preprocessor` namespace in our k8s cluster with `kubectl apply -f k8s_deployment.yaml -n api-preprocessor`.

Note: k8s deployments can also be defined and managed via Terraform. The above yaml will be migrated into terraform management after prototyping is done.

Additionally, this sets up terraform in this repo so that it can manage kubernetes resources.
New k8s resources are defined for the k8s namespace of this application, as well as the gcp and kubernetes service accounts (and bindings) necessary to give pods deployed in this namespace access to GCP resources bound to the gcp service account.