### PR TITLE
add generic ephemeral volume

### DIFF
--- a/helm/templates/api-preprocessor-cronjob.yaml
+++ b/helm/templates/api-preprocessor-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
                   value: INFO
               volumeMounts:
                 - mountPath: "/tmp"
-                  name: local-zarr-cache
+                  name: zarr-cache
               resources:
                 requests:
                   cpu: "2"


### PR DESCRIPTION
## Description
The max size for a gcp autopilot k8s ephemeral volume is 10Gi. This is not enough for us to localize the zarr store.

Instead, we create a generic ephemeral volume of 150Gi, and mount it to the pod. This gets automatically provisioned from Compute Engine storage.

Refs:
https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#min-max-requests
https://cloud.google.com/kubernetes-engine/docs/how-to/generic-ephemeral-volumes

Also changes the grace period to 600, which is the max allowable on GCP K8s autopilot.