### PR TITLE
update dockerfile w/ gcc; add more threads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,28 @@
-# Set python version
-# https://hub.docker.com/_/python
 ARG PYTHON_VERSION=3.12.2
 
-# -----------------------------
-# Stage 1: Install dependencies
-# -----------------------------
 FROM python:${PYTHON_VERSION} AS venv
 
 # Tell pipenv to create venv in the current directory
 ENV PIPENV_VENV_IN_PROJECT=1
+# Allow statements and log messages to immediately appear in the Knative logs
+ENV PYTHONUNBUFFERED 1
 
-COPY Pipfile.lock /usr/src/
+COPY Pipfile.lock /
+WORKDIR /
 
-WORKDIR /usr/src
+# install build tools and compute crcmod/crc32c
+# used by service to download remote gs:// zarr store to k8s pod storage
+RUN apt-get update -yq && apt-get install -y build-essential
 
 # install production dependencies in pipenv-controlled virtual env
 RUN pip install -U pip
 RUN pip install pipenv
 RUN pipenv sync
 
-# ---------------------------------
-# Stage 2: Build a production image
-# ---------------------------------
-# Use the official slim Python image.
-FROM python:${PYTHON_VERSION}-slim AS prod
-
 # graphics libs for running cocip polygon gen
 # RUN apt-get update && apt-get install -y libgl1
 
-# Allow statements and log messages to immediately appear in the Knative logs
-ENV PYTHONUNBUFFERED 1
-
-# Copy the virtual environment from the previous stage
-RUN mkdir -v /usr/src/.venv
-COPY --from=venv /usr/src/.venv/ /usr/src/.venv/
-ENV PATH /usr/src/.venv/bin:$PATH
-
 # Copy the application code
-WORKDIR /
 COPY lib lib
 COPY main.py .
 

--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -408,7 +408,7 @@ class ZarrRemoteFileHandler:
     """
 
     TMPDIR = "/tmp"
-    DOWNLOAD_THREAD_CNT = 10
+    DOWNLOAD_THREAD_CNT = 100
 
     def __init__(self, job: ApiPreprocessorJob, source: str):
         """


### PR DESCRIPTION
## Description
It isn't immediately clear if this will resolve #35 .  A quick look at the setup.py of `google-crc32c`, which is a transitive dependency of google.storage... appears to indicate that, by default, it will be set up to use a global install of crc32c.

To avoid any issues with not copying over any necessary c-binary dependencies into the multi-stage build, the multi-stage build was removed from the dockerfile, and installs gcc in the linux envn't before installing pip dependencies.

Once the warning in #35 is resolved, and the zarr store copy is using the c-binary for crc32c checksum... then we can consider re-implementing multi-stage build and dig in a bit deeper. Removal of the multi-stage build seems to have increased image size from about 700mb to 1.7gb.
