### PR TITLE
Deploy pods to T2d instance type

### DIFF
--- a/helm/templates/api-preprocessor-cronjob.yaml
+++ b/helm/templates/api-preprocessor-cronjob.yaml
@@ -18,6 +18,10 @@ spec:
       backoffLimit: 10
       template:
         spec:
+          nodeSelector:
+            # See compute optimization discussion:
+            # https://github.com/contrailcirrus/api-preprocessor/issues/35#issuecomment-2040558780
+            cloud.google.com/compute-class: "Scale-Out"
           restartPolicy: Never
           serviceAccountName: api-preprocessor-k8s-default-sa
           # terminationGracePeriodSeconds should be greater than the time to


### PR DESCRIPTION
Improves network throughput by ~2x over similarly specced E2 instance type (default).

See discussion at: https://github.com/contrailcirrus/api-preprocessor/issues/35#issuecomment-2040558780