### PR TITLE
update privilege

### DIFF
--- a/.cloud/auth.tf
+++ b/.cloud/auth.tf
@@ -20,6 +20,7 @@ resource "google_project_iam_custom_role" "api_preprocessor_role" {
     "storage.objects.create",
     "storage.objects.get",
     "storage.objects.list",
+    "storage.objects.delete",
     "pubsub.snapshots.seek",
     "pubsub.subscriptions.consume",
     "pubsub.topics.attachSubscription",


### PR DESCRIPTION
## Description

Closes #46 

Adds storage object delete privileges to the api-preprocessor.  See Issue.

This appears to be a transient bug (surfacing if and only if the api preprocessor has a write interrupt and resumable upload to gcs).

