### PR TITLE
update geojson for BigQuery compliance

### DIFF
--- a/.cloud/auth.tf
+++ b/.cloud/auth.tf
@@ -21,6 +21,7 @@ resource "google_project_iam_custom_role" "api_preprocessor_role" {
     "storage.objects.get",
     "storage.objects.list",
     "storage.objects.delete",
+    "pubsub.topics.publish",
     "pubsub.snapshots.seek",
     "pubsub.subscriptions.consume",
     "pubsub.topics.attachSubscription",


### PR DESCRIPTION
## Description
Currently, our polygon generator generates MultiPolygon geojson objects.  Our format includes a third optional element in the definition of our geo Points (altitude).

Bigquery does not support the use of the third positional element in its GEOGRAPHY types, hence casting to this type from our geojson representation will fail.

As such, we pop the third element from the MultiPolygon objects, before serializing and exporting to bigquery.

Additionally, this PR fixes a missing permission in IAM.