### PR TITLE
change to performance class

### DIFF
--- a/helm/templates/api-preprocessor-cronjob.yaml
+++ b/helm/templates/api-preprocessor-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
           nodeSelector:
             # See compute optimization discussion:
             # https://github.com/contrailcirrus/api-preprocessor/issues/35#issuecomment-2040558780
-            cloud.google.com/compute-class: "Scale-Out"
+            cloud.google.com/compute-class: "Performance"
           restartPolicy: Never
           serviceAccountName: api-preprocessor-k8s-default-sa
           # terminationGracePeriodSeconds should be greater than the time to


### PR DESCRIPTION
## Description
This experiments with changing the api-preprocessor pods from running on Scale-Out to Performance class.

Previously, we had kubectl yell at us when attempting to use the Performance class (saying it was not supported, which contradicts [Google Autopilot Compute Class](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-compute-classes) documentation. The previous attempt also explicitly specified the machine type, where here we leave it to Autopilot to decide.

Motivation for this change is both to experiment with possible compute and data throughput performance gains (decreased e2e runtime latency), but also to optimize for resource allocation. Scale-Out enforces a 1:4 cpu to mem ratio. At present, we are overprovisioned in mem by about 2x, but can't decrease allocation due to this fixed ratio.

### Benchmark
Currently, the api-preprocessor is running with the current stats.

compute-class: Scale-Out
vcpu: 1.15
mem: 4.6 gb

average e2e runtime: ~6min. (900-1k jobs processed by 60 pods in 1.5hrs; noting that bootup hysteresis adds some biasing here)