### PR TITLE
re-implement Scale-Out class

### DIFF
--- a/helm/templates/api-preprocessor-cronjob.yaml
+++ b/helm/templates/api-preprocessor-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
           nodeSelector:
             # See compute optimization discussion:
             # https://github.com/contrailcirrus/api-preprocessor/issues/35#issuecomment-2040558780
-            cloud.google.com/compute-class: "Balanced"
+            cloud.google.com/compute-class: "Scale-Out"
           restartPolicy: Never
           serviceAccountName: api-preprocessor-k8s-default-sa
           # terminationGracePeriodSeconds should be greater than the time to
@@ -43,9 +43,10 @@ spec:
                 - name: LOG_LEVEL
                   value: INFO
               resources:
-                requests:
-                  cpu: "1.5"
-                  memory: "6000Mi"
-                limits:
-                  cpu: "1.5"
-                  memory: "6000Mi"
+                resources:
+                  requests:
+                    cpu: "1.15"
+                    memory: "4600Mi"
+                  limits:
+                    cpu: "1.15"
+                    memory: "4600Mi"


### PR DESCRIPTION
## Description
This returns the API preprocessor to the Scale-Out class.

Previous PR/commits experimented with the Performance and Balanced class.
The Performance class was proven to be unsupported by GKE Autopilot (despite google documentation).

The Balanced class showed similar performance to Scale-Out, but on the aggregate after some soak testing, appears to be slightly less performant overall.

As such, we will settle on the Scale-Out class as our optimal compute substrate for now.