### PR TITLE
fix geojson format

### DIFF
--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -228,7 +228,7 @@ class CocipHandler:
         poly: geojson.FeatureCollection
         out: list[tuple[int, str]] = []
         for thres, poly in zip(self.REGIONS_THRESHOLDS, self._polygons):
-            feature_geom = dict(poly.features["geometry"])
+            feature_geom = dict(poly.features[0]["geometry"])
             # remove third positional element in each point (lon, lat, alt)
             for polygon in feature_geom["coordinates"]:
                 for linestring in polygon:


### PR DESCRIPTION
## Description
This fixes the geojson marshaling for the polygon objects that are exported to GCS (and back the /v1 API).
Previously, the `feature` object was not wrapped in a json array when exported to the json string literal blob.
This fixes the marshaling from the `geojson.FeatureCollection` object to that blob.

**Previously**
```json
{
    "type": "FeatureCollection",
    "features":  {"type": "Feature", ... }
}
```


***Now**
```json
{
    "type": "FeatureCollection",
    "features": [
        {"type": "Feature", ... }
    ]
}
```

### Breaking changes
This is a breaking change, as it will create a mixture of formats for the blobs in our persisted history in GCS.

### Remediation
Given that (to the best of our knowledge) we have no clients currently relying and integrated with the current format, let us simply expunge/delete from GCS all history of persisted geojson files of the older format.

Luckily, we can still retain all our geojson polygon history that is in BigQuery in case those data are useful in the future (we store geojson Features in bigquery, not FeatureCollections, thus this change has no affect on those BQ data).

Lastly, this will break the new CAE shim.
This [line](https://github.com/contrailcirrus/data-staging/blob/292bc1dbca7df8ca5e41c5a1420dca50e6f43543/contrail-forecast-CAE/app/main.py#L117) will need to be modified to `feature = blob_content["features"][0]`
