### PR TITLE
add spot instance node selector

### DIFF
--- a/helm/templates/api-preprocessor-cronjob.yaml
+++ b/helm/templates/api-preprocessor-cronjob.yaml
@@ -23,6 +23,7 @@ spec:
             # See compute optimization discussion:
             # https://github.com/contrailcirrus/api-preprocessor/issues/35#issuecomment-2040558780
             cloud.google.com/compute-class: "Scale-Out"
+            cloud.google.com/gke-spot: "true"
           restartPolicy: OnFailure
           serviceAccountName: api-preprocessor-k8s-default-sa
           # terminationGracePeriodSeconds should be greater than the time to


### PR DESCRIPTION
## Description
This updates the api-preprocessor to use spot instances.
A spot instance may be evicted by k8s at any time, if the resources are required elsewhere.
But, spot instances are about 1/6th the cost.

## Deploy
These changes will be deployed to prod, and monitored on the next api-preprocessor cron run.
The behavior of the api-preprocessor will furthermore be monitored over the next few days.

Specifically, we need to build some general observations about resource availability and consistency for these spot instances.

Possible complications/frustrations may include a) higher frequency of dead-lettering (due to failed jobs arising from evicted pods), b) unacceptably low resource availability, resulting in only a subset of jobs being completed for a given cron run (i.e. building a backlog of unprocessed jobs, and adversely affecting out soft service obligations of providing CoCIp grid outputs at predictable intervals via the API).