### PR TITLE
netCDF and geoJSON format updates

### DIFF
--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -442,7 +442,7 @@ class CocipHandler:
             dt_frt = datetime.fromtimestamp(job.model_run_at, tz=UTC).replace(
                 tzinfo=None
             )
-            ds = ds.assign_coords(forecast_reference_time=("time", np.array([dt_frt])))
+            ds = ds.assign_coords(forecast_reference_time=("time", np.array([dt_frt], dtype='datetime64')))
 
             # convert vertical coordinates to flight_level
             ds = ds.rename({"level": "flight_level"})

--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -577,6 +577,12 @@ class CocipHandler:
         poly = mda.to_polygon_feature(**params)
         geojson_blob = geojson.FeatureCollection([poly])
 
+        if len(geojson_blob.features) > 1:
+            logger.error(
+                "expected only 1 features in CoCiP geoJSON polygon object. "
+                "found multiple."
+            )
+
         # add metadata properties into the `feature`
         geojson_blob.features[0].properties = {
             "aircraft_class": job.aircraft_class,

--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -428,9 +428,6 @@ class CocipHandler:
             # minify netcdf content saved to disk
             # ----------
             ds.attrs = {
-                "forecast_reference_time": datetime.fromtimestamp(
-                    job.model_run_at, tz=UTC
-                ).strftime("%Y-%m-%dT%H:%H:%SZ"),
                 "aircraft_class": job.aircraft_class,
             }
             # drop extraneous coords
@@ -438,6 +435,12 @@ class CocipHandler:
             for name, _ in ds.coords.items():
                 if name not in req_coords:
                     ds = ds.drop_vars(name)
+
+            # add `forecast_reference_time` as a coordinate sidecar to `time`
+            dt_frt = datetime.fromtimestamp(job.model_run_at, tz=UTC).replace(
+                tzinfo=None
+            )
+            ds = ds.assign_coords(forecast_reference_time=("time", np.array([dt_frt])))
 
             # convert vertical coordinates to flight_level
             ds = ds.rename({"level": "flight_level"})
@@ -454,7 +457,16 @@ class CocipHandler:
 
             # drop any non-target data vars (i.e. anything other than `ef_per_m`
             # and, reorder dimensions and variables (optics change only)
-            ds = ds[["longitude", "latitude", "flight_level", "time", "ef_per_m"]]
+            ds = ds[
+                [
+                    "longitude",
+                    "latitude",
+                    "flight_level",
+                    "time",
+                    "forecast_reference_time",
+                    "ef_per_m",
+                ]
+            ]
 
             # compression reduces filesize by ~10x
             ds["ef_per_m"].encoding.update({"zlib": True, "complevel": 1})

--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -515,7 +515,7 @@ class CocipHandler:
             dt_frt = datetime.fromtimestamp(job.model_run_at, tz=UTC).replace(
                 tzinfo=None
             )
-            ds = ds.assign_coords(forecast_reference_time=("time", np.array([dt_frt])))
+            ds = ds.assign_coords(forecast_reference_time=("time", np.array([dt_frt], dtype='datetime64')))
 
             # convert vertical coordinates to flight_level
             ds = ds.rename({"level": "flight_level"})


### PR DESCRIPTION
## Description
This PR addresses changes to the geoJSON blob object and netCDF blob objects.

These changes follow updates to our API and data contracts. See [here](https://github.com/contrailcirrus/contrail-forecast/pull/4/files).

## Changes
- remove `forecast_reference_time` as a dataset attribute in the two netCDF blobs saved to GCS (blob1: `ef_per_m` dataset, blob2: `contrails` dataset)
- add `forecast_reference_time` as a non-indexed coordinate, referencing the `time` dimension, to both of the above-mentioned netCDF blobs
- add metadata into the `.features[].properties` of the geoJSON MultiPolygon object