### PR TITLE
#major update geoJSON and netCDF metadata

### DIFF
--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -594,12 +594,12 @@ class CocipHandler:
                     "aircraft_class": job.aircraft_class,
                     "time": datetime.fromtimestamp(
                         job.model_predicted_at, tz=UTC
-                    ).strftime("%Y-%m-%dT%H:%H:%SZ"),
+                    ).strftime("%Y-%m-%dT%H:%M:%SZ"),
                     "flight_level": flight_level,
                     "threshold": threshold,
                     "forecast_reference_time": datetime.fromtimestamp(
                         job.model_run_at, tz=UTC
-                    ).strftime("%Y-%m-%dT%H:%H:%SZ"),
+                    ).strftime("%Y-%m-%dT%H:%M:%SZ"),
                 }
             }
         )


### PR DESCRIPTION
## Description
Prod release of changes commensurate with the `2024-11-14` changelog of the API interface contract [HERE](https://github.com/contrailcirrus/contrail-forecast/blob/main/docs/specs/forecast-api.md#20241114).

## Changes
*Structural changes* <br>
- `features[0].properties` populated in the geoJSON polygon/regions object. k-vs provide context & uniquely define the geoJSON resource.
- `forecast_reference_time` migrated from dataset attr to dataset non-indexed coord in netCDF objects