### PR TITLE
add log message exclusions in alert trigger

### DIFF
--- a/.cloud/alerts.tf
+++ b/.cloud/alerts.tf
@@ -11,6 +11,8 @@ resource "google_monitoring_alert_policy" "k8scronjob_api_preprocessor_prod_erro
         resource.labels.namespace_name="api-preprocessor-prod"
         labels.k8s-pod/job-name:"api-preprocessor-"
         severity>=ERROR
+        textPayload!="WARNING: All log messages before absl::InitializeLog() is called are written to STDERR"
+        jsonPayload.message!="grpc_wait_for_shutdown_with_timeout() timed out."
         EOF
     }
   }


### PR DESCRIPTION
## Description
With a recent prod [deployment](https://github.com/contrailcirrus/api-preprocessor/commit/bfea900b4ee66076b5e455e50f320e1725f2e8b3), we started observing some ERROR level log messages we hadn't seen before:

```text
"WARNING: All log messages before absl::InitializeLog() is called are written to STDERR"
"grpc_wait_for_shutdown_with_timeout() timed out."
```

I have not been able to identify the root of these messages. They are not from our application itself, and the grpc reference suggests that this is from some underlying process within the GCP pubsub client. Furthermore, there is no `raise` to our application level, so this appears to be buried somewhere.
Regardless, it does not seem to be affecting the expected behavior of the api-preprocessor application, and I suspect this is due to some interplay of the container orchestration timing and the initialization/termination sequencing for the pubsub underlying gcp handlers.

Here, we take a practical approach, and simply ignore these messages in the logs. This update avoids triggering an alerting SMS on these two log messages.